### PR TITLE
separate AIS message reading and decoding

### DIFF
--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -99,8 +99,12 @@ ais_base::VesselInformation AIS::getVesselInformation(ais::message_05 const& mes
     info.time = base::Time::now();
     info.mmsi = message.get_mmsi();
     info.imo = message.get_imo_number();
-    info.name = message.get_shipname();
-    info.call_sign = message.get_callsign();
+    string name = message.get_shipname();
+    int first_not_space = name.find_last_not_of(" ");
+    info.name = name.substr(0, first_not_space + 1);
+    string call_sign = message.get_callsign();
+    first_not_space = call_sign.find_last_not_of(" ");
+    info.call_sign = call_sign.substr(0, first_not_space + 1);
     info.length = message.get_to_bow() + message.get_to_stern();
     info.width = message.get_to_port() + message.get_to_starboard();
     info.draft = static_cast<float>(message.get_draught()) / 10;

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -103,7 +103,7 @@ ais_base::VesselInformation AIS::getVesselInformation(ais::message_05 const& mes
     info.call_sign = message.get_callsign();
     info.length = message.get_to_bow() + message.get_to_stern();
     info.width = message.get_to_port() + message.get_to_starboard();
-    info.draft = message.get_draught();
+    info.draft = static_cast<float>(message.get_draught()) / 10;
     info.ship_type = static_cast<ais_base::ShipType>(
         message.get_shiptype()
     );

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -12,12 +12,38 @@
 
 namespace nmea0183 {
     class AIS {
-        Driver& m_driver;
+        uint32_t mDiscardedSentenceCount = 0;
+        Driver& mDriver;
+        std::vector<std::pair<std::string, std::uint32_t>> payloads;
 
     public:
         AIS(Driver& driver);
 
+        /** Read an AIS message
+         *
+         * This calls the underlying NMEA driver until a full
+         * AIS message is received and returns it
+         */
         std::unique_ptr<marnav::ais::message> readMessage();
+
+        /**
+         * Process a NMEA sentence and return an AIS message if one is
+         * available
+         *
+         * AIS messages are made of multiple NMEA sentences. This adds a
+         * sentence to the message reconstruction, and returns a full
+         * AIS message once all fragments of one are received.
+         *
+         * The returned value will either be NULL or point to an AIS message
+         */
+        std::unique_ptr<marnav::ais::message> processSentence(
+            marnav::nmea::sentence const& sentence
+        );
+
+        /** Returns the count of sentences that have been discarded because
+         * of some reordering/reassembly issues
+         */
+        uint32_t getDiscardedSentenceCount() const;
 
         static ais_base::Position getPosition(
             marnav::ais::message_01 const& message);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ endforeach()
 
 rock_library(nmea0183
     SOURCES Driver.cpp AIS.cpp
-    HEADERS Driver.hpp AIS.hpp
+    HEADERS Driver.hpp AIS.hpp Exceptions.hpp
     DEPS_PKGCONFIG iodrivers_base ais_base)
 target_link_libraries(nmea0183 marnav::marnav)
 

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -60,8 +60,13 @@ int Driver::extractPacket(uint8_t const* buffer, size_t buffer_size) const {
 std::unique_ptr<marnav::nmea::sentence> Driver::readSentence() {
     uint8_t buffer[BUFFER_SIZE];
     int sentence_size = readPacket(buffer, BUFFER_SIZE);
-    return marnav::nmea::make_sentence(
-        std::string(reinterpret_cast<char*>(buffer),
-                    reinterpret_cast<char*>(buffer + sentence_size - 2))
-    );
+    try {
+        return marnav::nmea::make_sentence(
+            std::string(reinterpret_cast<char*>(buffer),
+                        reinterpret_cast<char*>(buffer + sentence_size - 2))
+        );
+    }
+    catch (std::exception const& e) {
+        throw MarnavParsingError(e.what());
+    }
 }

--- a/src/Driver.hpp
+++ b/src/Driver.hpp
@@ -4,6 +4,7 @@
 #include <iodrivers_base/Driver.hpp>
 #include <marnav/nmea/nmea.hpp>
 #include <marnav/nmea/sentence.hpp>
+#include <nmea0183/Exceptions.hpp>
 
 namespace nmea0183 {
     /**

--- a/src/Exceptions.hpp
+++ b/src/Exceptions.hpp
@@ -1,0 +1,12 @@
+#ifndef NMEA0183_EXCEPTIONS_HPP
+#define NMEA0183_EXCEPTIONS_HPP
+
+#include <stdexcept>
+
+namespace nmea0183 {
+    struct MarnavParsingError : std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+}
+
+#endif

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -173,7 +173,7 @@ TEST_F(AISTest, it_converts_marnav_message05_into_a_VesselInformation) {
     ASSERT_EQ(6, info.width);
     ASSERT_EQ(base::Vector3d(10, 4, 0), info.reference_position);
     ASSERT_EQ(ais_base::EPFD_COMBINED_GPS_GLONASS, info.epfd_fix);
-    ASSERT_EQ(7, info.draft);
+    ASSERT_NEAR(0.7, info.draft, 1e-2);
 }
 
 TEST_F(AISTest, it_sets_SHIP_TYPE_NOT_AVAILABLE_for_ship_types_lower_than_MIN) {

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -30,12 +30,30 @@ const std::vector<std::string> ais_strings = {
     "!AIVDM,2,2,3,B,1@0000000000000,2*55\r\n"
 };
 
+const std::vector<std::string> invalid_ais_strings = {
+    "$AIVDM,2,1,3,B,55P5TL01VIaAL@7WKO@BplU@<PDhh000000001S;AJ::4A80?4i@E53,0*53\r\n",
+    "!AIVDM,2,2,3,B,1@0000000000000,2*55\r\n"
+};
+
 TEST_F(AISTest, it_reassembles_AIS_messages) {
     pushStringToDriver(ais_strings[0]);
     pushStringToDriver(ais_strings[1]);
 
     auto msg = ais.readMessage();
     ASSERT_EQ(marnav::ais::message_id::static_and_voyage_related_data, msg->type());
+    ASSERT_EQ(0, ais.getDiscardedSentenceCount());
+}
+
+TEST_F(AISTest, it_throws_MarnavParsingError_if_the_embedded_message_is_invalid) {
+    pushStringToDriver(invalid_ais_strings[0]);
+    pushStringToDriver(invalid_ais_strings[1]);
+
+    // Separate reading sentences and message, to make sure that the messages
+    // were indeed valid from the p.o.v. of sentence formatting
+    auto sentence0 = driver.readSentence();
+    auto sentence1 = driver.readSentence();
+    ais.processSentence(*sentence0);
+    ASSERT_THROW(ais.processSentence(*sentence1), MarnavParsingError);
 }
 
 TEST_F(AISTest, it_skips_sentences_that_do_not_follow_each_other) {
@@ -45,6 +63,7 @@ TEST_F(AISTest, it_skips_sentences_that_do_not_follow_each_other) {
 
     auto msg = ais.readMessage();
     ASSERT_EQ(marnav::ais::message_id::static_and_voyage_related_data, msg->type());
+    ASSERT_EQ(1, ais.getDiscardedSentenceCount());
 }
 
 TEST_F(AISTest, it_drops_a_sentence_that_do_not_start_a_multisentence_message) {
@@ -54,6 +73,7 @@ TEST_F(AISTest, it_drops_a_sentence_that_do_not_start_a_multisentence_message) {
 
     auto msg = ais.readMessage();
     ASSERT_EQ(marnav::ais::message_id::static_and_voyage_related_data, msg->type());
+    ASSERT_EQ(1, ais.getDiscardedSentenceCount());
 }
 
 TEST_F(AISTest, it_converts_marnav_message01_into_a_Position) {

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -176,6 +176,20 @@ TEST_F(AISTest, it_converts_marnav_message05_into_a_VesselInformation) {
     ASSERT_NEAR(0.7, info.draft, 1e-2);
 }
 
+TEST_F(AISTest, it_removes_trailing_spaces_in_the_name) {
+    ais::message_05 msg;
+    msg.set_shipname("NAME with SPACES   ");
+    auto info = AIS::getVesselInformation(msg);
+    ASSERT_EQ("NAME with SPACES", info.name);
+}
+
+TEST_F(AISTest, it_removes_trailing_spaces_in_the_callsign) {
+    ais::message_05 msg;
+    msg.set_callsign("CALL    ");
+    auto info = AIS::getVesselInformation(msg);
+    ASSERT_EQ("CALL", info.call_sign);
+}
+
 TEST_F(AISTest, it_sets_SHIP_TYPE_NOT_AVAILABLE_for_ship_types_lower_than_MIN) {
     ais::message_05 msg;
     msg.set_shiptype(static_cast<ais::ship_type>(ais_base::SHIP_TYPE_MIN - 1));

--- a/test/test_Driver.cpp
+++ b/test/test_Driver.cpp
@@ -26,6 +26,12 @@ TEST_F(DriverTest, it_accepts_a_valid_NMEA_sentence) {
     ASSERT_EQ("APB", sentence->tag());
 }
 
+TEST_F(DriverTest, it_throws_MarnavParsingError_if_a_valid_sentence_is_extracted_that_cannot_be_parsed) {
+    string msg = "$GPZDA,160012.71,03,2004,-1,00*51\r\n";
+    pushStringToDriver(msg);
+    ASSERT_THROW(driver.readSentence(), MarnavParsingError);
+}
+
 TEST_F(DriverTest, it_handles_partial_messages) {
     string msg = "$GPAPB,A,A,0.10,R,N,V,V,11.0,M,DEST,11.0,M,11.0,M*12\r\n";
     for (size_t i = 0; i < msg.size() - 1; ++i) {


### PR DESCRIPTION
This is to enable the refactoring in the orogen component, separating the reading
(in a base task) with the processing (in sensor-specific tasks)