### PR TITLE
fix conversion from AIS-reported yaw and course to Rock's convention

### DIFF
--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -76,14 +76,14 @@ ais_base::Position AIS::getPosition(ais::message_01 const& message) {
     ais_base::Position position;
     position.time = base::Time::now();
     position.mmsi = message.get_mmsi();
-    position.course_over_ground = optionalAngleToRock(message.get_cog());
+    position.course_over_ground = optionalAngleToRock(message.get_cog()) * -1;
     position.longitude = optionalAngleToRock(message.get_longitude());
     position.latitude = optionalAngleToRock(message.get_latitude());
     position.status = static_cast<ais_base::NavigationalStatus>(
         message.get_nav_status()
     );
     position.high_accuracy_position = message.get_position_accuracy();
-    position.yaw = optionalAngleToRock(message.get_hdg());
+    position.yaw = optionalAngleToRock(message.get_hdg()) * -1;
     position.speed_over_ground = optionalFloatToRock(message.get_sog());
     position.maneuver_indicator = static_cast<ais_base::ManeuverIndicator>(
         message.get_maneuver_indicator()

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -97,8 +97,8 @@ TEST_F(AISTest, it_converts_marnav_message01_into_a_Position) {
     ASSERT_TRUE(base::isUnknown(position.yaw_velocity)); // not converted
     ASSERT_FLOAT_EQ(10, position.speed_over_ground);
     ASSERT_TRUE(position.high_accuracy_position);
-    ASSERT_FLOAT_EQ(15, position.course_over_ground.getDeg());
-    ASSERT_FLOAT_EQ(25, position.yaw.getDeg());
+    ASSERT_FLOAT_EQ(-15, position.course_over_ground.getDeg());
+    ASSERT_FLOAT_EQ(-25, position.yaw.getDeg());
     ASSERT_EQ(ais_base::MANEUVER_NORMAL, position.maneuver_indicator);
     ASSERT_TRUE(position.raim);
     ASSERT_EQ(1234, position.radio_status);


### PR DESCRIPTION
AIS uses positive clockwise while rock is using the opposite.