### PR TITLE
chore: move position correction code to lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
 cmake_minimum_required(VERSION 2.6)
+SET (CMAKE_CXX_STANDARD 17)
 find_package(Rock)
 rock_init(nmea0183 0.1)
 rock_standard_layout()

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -9,7 +9,7 @@ using namespace marnav;
 using namespace nmea0183;
 
 double constexpr KNOTS_TO_MS = 0.514444;
-double constexpr MIN_SPEED_THRESHOLD = 0.2;
+double constexpr MIN_SPEED_FOR_VALID_COURSE = 0.2;
 
 AIS::AIS(Driver& driver)
     : mDriver(driver)
@@ -150,7 +150,7 @@ std::pair<Eigen::Quaterniond, ais_base::PositionCorrectionStatus> vesselToWorldO
     }
     else if (course_over_ground.has_value() &&
              !std::isnan(course_over_ground.value().getRad()) &&
-             speed_over_ground >= MIN_SPEED_THRESHOLD) {
+             speed_over_ground >= MIN_SPEED_FOR_VALID_COURSE) {
         return {Eigen::Quaterniond(Eigen::AngleAxisd(course_over_ground.value().getRad(),
                     Eigen::Vector3d::UnitZ())),
             ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_COURSE};

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -137,13 +137,13 @@ std::pair<Eigen::Quaterniond, ais_base::PositionCorrectionStatus> vesselToWorldO
     const std::optional<base::Angle>& course_over_ground,
     double speed_over_ground)
 {
-    if (yaw.has_value() && !std::isnan(yaw.value().getDeg())) {
+    if (yaw.has_value() && !std::isnan(yaw.value().getRad())) {
         return {Eigen::Quaterniond(
                     Eigen::AngleAxisd(yaw.value().getRad(), Eigen::Vector3d::UnitZ())),
             ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_HEADING};
     }
     else if (course_over_ground.has_value() &&
-             !std::isnan(course_over_ground.value().getDeg()) &&
+             !std::isnan(course_over_ground.value().getRad()) &&
              speed_over_ground >= MIN_SPEED_THRESHOLD) {
         return {Eigen::Quaterniond(Eigen::AngleAxisd(course_over_ground.value().getRad(),
                     Eigen::Vector3d::UnitZ())),
@@ -208,9 +208,9 @@ ais_base::Position AIS::applyPositionCorrection(ais_base::Position const& positi
 {
     if (std::isnan(position.yaw.getRad()) &&
         std::isnan(position.course_over_ground.getRad())) {
-        std::string error_msg = "Position can't be corrected because both 'yaw' "
-                                "and 'course_over_ground' values are missing.";
-        LOG_ERROR_S << error_msg << std::endl;
+        LOG_ERROR_S << "Position can't be corrected because both 'yaw' "
+                       "and 'course_over_ground' values are missing."
+                    << std::endl;
         return position;
     }
 
@@ -219,10 +219,9 @@ ais_base::Position AIS::applyPositionCorrection(ais_base::Position const& positi
         position.speed_over_ground);
 
     if (status == ais_base::PositionCorrectionStatus::POSITION_RAW) {
-        std::string error_msg =
-            "Position can't be corrected because 'yaw' value is missing and "
-            "'speed_over_ground' is below the threshold.";
-        LOG_ERROR_S << error_msg << std::endl;
+        LOG_ERROR_S << "Position can't be corrected because 'yaw' value is missing and "
+                       "'speed_over_ground' is below the threshold."
+                    << std::endl;
         return position;
     }
 

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -225,7 +225,7 @@ ais_base::Position AIS::applyPositionCorrection(
         position_value.speed_over_ground);
 
     if (status == ais_base::PositionCorrectionStatus::POSITION_RAW) {
-        LOG_ERROR_S << "Position can't be corrected because 'yaw' value is missing and "
+        LOG_DEBUG_S << "Position can't be corrected because 'yaw' value is missing and "
                        "'speed_over_ground' is below the threshold."
                     << std::endl;
         return position_value;

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -12,14 +12,14 @@ double constexpr KNOTS_TO_MS = 0.514444;
 double constexpr MIN_SPEED_FOR_VALID_COURSE = 0.2;
 
 AIS::AIS(Driver& driver)
-    : mDriver(driver)
+    : m_driver(driver)
 {
 }
 
 unique_ptr<ais::message> AIS::readMessage()
 {
     while (true) {
-        auto sentence = mDriver.readSentence();
+        auto sentence = m_driver.readSentence();
         auto msg = processSentence(*sentence);
         if (msg) {
             return msg;
@@ -29,7 +29,7 @@ unique_ptr<ais::message> AIS::readMessage()
 
 uint32_t AIS::getDiscardedSentenceCount() const
 {
-    return mDiscardedSentenceCount;
+    return m_discarded_sentence_count;
 }
 
 unique_ptr<ais::message> AIS::processSentence(nmea::sentence const& sentence)
@@ -43,12 +43,12 @@ unique_ptr<ais::message> AIS::processSentence(nmea::sentence const& sentence)
     size_t n_fragments = vdm->get_n_fragments();
     size_t fragment = vdm->get_fragment();
     if (fragment != payloads.size() + 1) {
-        mDiscardedSentenceCount += payloads.size();
+        m_discarded_sentence_count += payloads.size();
         payloads.clear();
 
         // Go on if we're receiving the first fragment of a new message
         if (fragment != 1) {
-            mDiscardedSentenceCount++;
+            m_discarded_sentence_count++;
             return unique_ptr<ais::message>();
         }
     }

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -214,6 +214,7 @@ ais_base::Position AIS::applyPositionCorrection(ais_base::Position const& positi
         LOG_DEBUG_S << "Position can't be corrected because 'yaw' value is missing and "
                        "'speed_over_ground' is below the threshold."
                     << std::endl;
+        sensor2world_gps.correction_status = status;
         return sensor2world_gps;
     }
 

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -155,11 +155,11 @@ std::pair<Eigen::Quaterniond, ais_base::PositionCorrectionStatus> vesselToWorldO
     }
 }
 
-base::Vector3d sensorToVesselInWorldPose(base::Vector3d sensor2vessel_pos,
+base::Vector3d sensorToVesselInWorldPose(base::Vector3d sensor2vessel_in_vessel_pos,
     Eigen::Quaterniond vessel2world_ori)
 {
     base::Vector3d sensor2vessel_in_world_pos;
-    sensor2vessel_in_world_pos = vessel2world_ori * sensor2vessel_pos;
+    sensor2vessel_in_world_pos = vessel2world_ori * sensor2vessel_in_vessel_pos;
 
     return sensor2vessel_in_world_pos;
 }
@@ -203,7 +203,7 @@ std::pair<base::Angle, base::Angle> convertUTMToGPSInWorldFrame(
 }
 
 ais_base::Position AIS::applyPositionCorrection(ais_base::Position const& position,
-    base::Vector3d const& vessel_reference_position,
+    base::Vector3d const& sensor2vessel_in_vessel_pos,
     gps_base::UTMConverter utm_converter)
 {
     if (std::isnan(position.yaw.getRad()) &&
@@ -226,7 +226,7 @@ ais_base::Position AIS::applyPositionCorrection(ais_base::Position const& positi
     }
 
     auto sensor2vessel_in_world_pos =
-        sensorToVesselInWorldPose(vessel_reference_position, vessel2world_ori);
+        sensorToVesselInWorldPose(sensor2vessel_in_vessel_pos, vessel2world_ori);
 
     auto [latitude, longitude] =
         convertUTMToGPSInWorldFrame(convertGPSToUTM(position, utm_converter),

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -110,13 +110,19 @@ ais_base::VesselInformation AIS::getVesselInformation(ais::message_05 const& mes
     string call_sign = message.get_callsign();
     first_not_space = call_sign.find_last_not_of(" ");
     info.call_sign = call_sign.substr(0, first_not_space + 1);
-    info.length = message.get_to_bow() + message.get_to_stern();
-    info.width = message.get_to_port() + message.get_to_starboard();
+    auto get_to_stern = message.get_to_stern();
+    auto get_to_starboard = message.get_to_starboard();
+    float length = message.get_to_bow() + get_to_stern;
+    float width = message.get_to_port() + get_to_starboard;
+    info.length = length;
+    info.width = width;
     info.draft = static_cast<float>(message.get_draught()) / 10;
     info.ship_type = static_cast<ais_base::ShipType>(message.get_shiptype());
     info.epfd_fix = static_cast<ais_base::EPFDFixType>(message.get_epfd_fix());
     info.reference_position =
-        Eigen::Vector3d(message.get_to_stern(), message.get_to_starboard(), 0);
+        Eigen::Vector3d(static_cast<double>(get_to_stern - length / 2.0),
+            static_cast<double>(get_to_starboard - width / 2.0),
+            0);
 
     info.ensureEnumsValid();
     return info;

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -159,12 +159,11 @@ std::pair<Eigen::Quaterniond, ais_base::PositionCorrectionStatus> vesselToWorldO
     }
 }
 
-base::Vector3d sensorToVesselInWorldPose(
-    base::Vector3d const& sensor2vessel_in_vessel_pos,
+base::Vector3d sensorToVesselInWorldPose(base::Vector3d const& sensor2vessel_pos,
     Eigen::Quaterniond const& vessel2world_ori)
 {
     base::Vector3d sensor2vessel_in_world_pos;
-    sensor2vessel_in_world_pos = vessel2world_ori * sensor2vessel_in_vessel_pos;
+    sensor2vessel_in_world_pos = vessel2world_ori * sensor2vessel_pos;
 
     return sensor2vessel_in_world_pos;
 }
@@ -201,7 +200,7 @@ std::pair<base::Angle, base::Angle> convertUTMToGPSInWorldFrame(
 
 ais_base::Position AIS::applyPositionCorrection(
     std::optional<ais_base::Position> position,
-    base::Vector3d const& sensor2vessel_in_vessel_pos,
+    base::Vector3d const& sensor2vessel_pos,
     gps_base::UTMConverter const& utm_converter)
 {
     if (!position.has_value()) {
@@ -232,7 +231,7 @@ ais_base::Position AIS::applyPositionCorrection(
     }
 
     auto sensor2vessel_in_world_pos =
-        sensorToVesselInWorldPose(sensor2vessel_in_vessel_pos, vessel2world_ori);
+        sensorToVesselInWorldPose(sensor2vessel_pos, vessel2world_ori);
 
     auto [latitude, longitude] =
         convertUTMToGPSInWorldFrame(convertGPSToUTM(position_value, utm_converter),

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -8,6 +8,7 @@ using namespace marnav;
 using namespace nmea0183;
 
 double constexpr KNOTS_TO_MS = 0.514444;
+double constexpr MIN_SPEED_THRESHOLD = 0.2;
 
 AIS::AIS(Driver& driver)
     : mDriver(driver)
@@ -135,14 +136,12 @@ std::pair<Eigen::Quaterniond, ais_base::PositionCorrectionStatus> vesselToWorldO
     const std::optional<base::Angle>& course_over_ground,
     double speed_over_ground)
 {
-    const double min_speed_threshold = 0.2;
-
     if (yaw.has_value()) {
         return {Eigen::Quaterniond(
                     Eigen::AngleAxisd(yaw.value().getRad(), Eigen::Vector3d::UnitZ())),
             ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_HEADING};
     }
-    else if (course_over_ground.has_value() && speed_over_ground >= min_speed_threshold) {
+    else if (course_over_ground.has_value() && speed_over_ground >= MIN_SPEED_THRESHOLD) {
         return {Eigen::Quaterniond(Eigen::AngleAxisd(course_over_ground.value().getRad(),
                     Eigen::Vector3d::UnitZ())),
             ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_COURSE};

--- a/src/AIS.cpp
+++ b/src/AIS.cpp
@@ -119,10 +119,9 @@ ais_base::VesselInformation AIS::getVesselInformation(ais::message_05 const& mes
     info.draft = static_cast<float>(message.get_draught()) / 10;
     info.ship_type = static_cast<ais_base::ShipType>(message.get_shiptype());
     info.epfd_fix = static_cast<ais_base::EPFDFixType>(message.get_epfd_fix());
-    info.reference_position =
-        Eigen::Vector3d(static_cast<double>(get_to_stern - length / 2.0),
-            static_cast<double>(get_to_starboard - width / 2.0),
-            0);
+    info.reference_position = Eigen::Vector3d(get_to_stern - (length / 2.0),
+        get_to_starboard - (width / 2.0),
+        0);
 
     info.ensureEnumsValid();
     return info;

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -17,8 +17,8 @@
 
 namespace nmea0183 {
     class AIS {
-        uint32_t mDiscardedSentenceCount = 0;
-        Driver& mDriver;
+        uint32_t m_discarded_sentence_count = 0;
+        Driver& m_driver;
         std::vector<std::pair<std::string, std::uint32_t>> payloads;
 
     public:

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -53,18 +53,38 @@ namespace nmea0183 {
          * Applies position correction using the vessel reference position and the sensor
          * offset
          *
-         * @param position the AIS position to be corrected
+         * @param position The vessel position to be corrected
          * @param sensor2vessel_pos The position of the sensor relative to the
          * vessel
          * @param utm_converter The UTM converter
          *
-         * @return The corrected AIS position with updated latitude, longitude, and
+         * @return The corrected vessel position with updated latitude, longitude, and
          * correction status
          */
         static ais_base::Position applyPositionCorrection(
-            std::optional<ais_base::Position> position,
+            ais_base::Position const& position,
             base::Vector3d const& sensor2vessel_pos,
             gps_base::UTMConverter const& utm_converter);
+
+        /**
+         * @brief Selects the vessel's orientation in the world frame based on available
+         * heading or course information
+         * - Uses yaw if available
+         * - Uses course over ground if yaw is not available and the speed over ground is
+         * above the minimum threshold
+         * - Uses Identity otherwise
+         *
+         * @param yaw The vessel's yaw (heading) angle
+         * @param course_over_ground The vessel's course over ground angle
+         * @param speed_over_ground The vessel's speed over ground
+         *
+         * @return A pair containing the vessel's orientation and the position correction
+         * status
+         */
+        static std::pair<Eigen::Quaterniond, ais_base::PositionCorrectionStatus>
+        selectVesselHeadingSource(base::Angle const& yaw,
+            base::Angle const& course_over_ground,
+            double speed_over_ground);
 
         static ais_base::Position getPosition(marnav::ais::message_01 const& message);
         static ais_base::VesselInformation getVesselInformation(

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -10,6 +10,11 @@
 #include <marnav/ais/message_01.hpp>
 #include <marnav/ais/message_05.hpp>
 
+#include <base/samples/RigidBodyState.hpp>
+#include <gps_base/BaseTypes.hpp>
+#include <gps_base/UTMConverter.hpp>
+#include <optional>
+
 namespace nmea0183 {
     class AIS {
         uint32_t mDiscardedSentenceCount = 0;
@@ -43,6 +48,23 @@ namespace nmea0183 {
          * of some reordering/reassembly issues
          */
         uint32_t getDiscardedSentenceCount() const;
+
+        /**
+         * Applies position correction using the vessel reference position and the sensor
+         * offset
+         *
+         * @param position the AIS position to be corrected
+         * @param vessel_reference_position The position of the vessel’s reference point
+         * relative to the sensor
+         * @param utm_converter The UTM converter
+         *
+         * @return The corrected AIS position with updated latitude, longitude, and
+         * correction status
+         */
+        static ais_base::Position applyPositionCorrection(
+            ais_base::Position const& position,
+            base::Vector3d const& vessel_reference_position,
+            gps_base::UTMConverter utm_converter);
 
         static ais_base::Position getPosition(marnav::ais::message_01 const& message);
         static ais_base::VesselInformation getVesselInformation(

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -54,8 +54,8 @@ namespace nmea0183 {
          * offset
          *
          * @param position the AIS position to be corrected
-         * @param vessel_reference_position The position of the vessel’s reference point
-         * relative to the sensor
+         * @param sensor2vessel_in_vessel_pos The position of the sensor relative to the
+         * vessel
          * @param utm_converter The UTM converter
          *
          * @return The corrected AIS position with updated latitude, longitude, and
@@ -63,7 +63,7 @@ namespace nmea0183 {
          */
         static ais_base::Position applyPositionCorrection(
             ais_base::Position const& position,
-            base::Vector3d const& vessel_reference_position,
+            base::Vector3d const& sensor2vessel_in_vessel_pos,
             gps_base::UTMConverter utm_converter);
 
         static ais_base::Position getPosition(marnav::ais::message_01 const& message);

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -10,10 +10,7 @@
 #include <marnav/ais/message_01.hpp>
 #include <marnav/ais/message_05.hpp>
 
-#include <base/samples/RigidBodyState.hpp>
-#include <gps_base/BaseTypes.hpp>
 #include <gps_base/UTMConverter.hpp>
-#include <optional>
 
 namespace nmea0183 {
     class AIS {

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -62,9 +62,9 @@ namespace nmea0183 {
          * correction status
          */
         static ais_base::Position applyPositionCorrection(
-            ais_base::Position const& position,
+            std::optional<ais_base::Position> position,
             base::Vector3d const& sensor2vessel_in_vessel_pos,
-            gps_base::UTMConverter utm_converter);
+            gps_base::UTMConverter const& utm_converter);
 
         static ais_base::Position getPosition(marnav::ais::message_01 const& message);
         static ais_base::VesselInformation getVesselInformation(

--- a/src/AIS.hpp
+++ b/src/AIS.hpp
@@ -54,7 +54,7 @@ namespace nmea0183 {
          * offset
          *
          * @param position the AIS position to be corrected
-         * @param sensor2vessel_in_vessel_pos The position of the sensor relative to the
+         * @param sensor2vessel_pos The position of the sensor relative to the
          * vessel
          * @param utm_converter The UTM converter
          *
@@ -63,7 +63,7 @@ namespace nmea0183 {
          */
         static ais_base::Position applyPositionCorrection(
             std::optional<ais_base::Position> position,
-            base::Vector3d const& sensor2vessel_in_vessel_pos,
+            base::Vector3d const& sensor2vessel_pos,
             gps_base::UTMConverter const& utm_converter);
 
         static ais_base::Position getPosition(marnav::ais::message_01 const& message);

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -318,14 +318,10 @@ TEST_F(AISTest, it_does_no_correction_if_both_yaw_and_cog_are_missing)
     base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    try {
+    ais_base::Position corrected_position =
         AIS::applyPositionCorrection(position, vessel_reference_position, utm_converter);
-    }
-    catch (const std::runtime_error& e) {
-        ASSERT_STREQ(e.what(),
-            "Position can't be corrected because both 'yaw' "
-            "and 'course_over_ground' values are missing.");
-    }
+    ASSERT_EQ(corrected_position.correction_status,
+        ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
 
 TEST_F(AISTest, it_does_no_correction_if_yaw_is_missing_and_sog_is_below_threshold)
@@ -340,12 +336,21 @@ TEST_F(AISTest, it_does_no_correction_if_yaw_is_missing_and_sog_is_below_thresho
     base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    try {
+    ais_base::Position corrected_position =
         AIS::applyPositionCorrection(position, vessel_reference_position, utm_converter);
+    ASSERT_EQ(corrected_position.correction_status,
+        ais_base::PositionCorrectionStatus::POSITION_RAW);
+}
+
+TEST_F(AISTest, it_throws_runtime_error_if_position_has_no_value)
+{
+    base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
+    gps_base::UTMConverter utm_converter = createUTMConverter();
+
+    try {
+        AIS::applyPositionCorrection({}, vessel_reference_position, utm_converter);
     }
     catch (const std::runtime_error& e) {
-        ASSERT_STREQ(e.what(),
-            "Position can't be corrected because 'yaw' value is missing and "
-            "'speed_over_ground' is below the threshold.");
+        ASSERT_STREQ(e.what(), "Position data is unavailable.");
     }
 }

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -28,7 +28,7 @@ struct AISTest : public ::testing::Test, public iodrivers_base::Fixture<Driver> 
 
     gps_base::UTMConverter createUTMConverter()
     {
-        gps_base::UTMConversionParameters parameters = {Eigen::Vector3d(0, 0, 0),
+        gps_base::UTMConversionParameters parameters = {Eigen::Vector3d(1, 1, 0),
             11,
             true};
         gps_base::UTMConverter converter(parameters);
@@ -190,7 +190,7 @@ TEST_F(AISTest, it_converts_marnav_message05_into_a_VesselInformation)
     ASSERT_EQ(ais_base::SHIP_TYPE_CARGO, info.ship_type);
     ASSERT_EQ(15, info.length);
     ASSERT_EQ(6, info.width);
-    ASSERT_EQ(base::Vector3d(10, 4, 0), info.reference_position);
+    ASSERT_EQ(base::Vector3d(2.5, 1, 0), info.reference_position);
     ASSERT_EQ(ais_base::EPFD_COMBINED_GPS_GLONASS, info.epfd_fix);
     ASSERT_NEAR(0.7, info.draft, 1e-2);
 }

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -346,6 +346,7 @@ TEST_F(AISTest, it_does_no_correction_if_no_yaw_and_sog_is_below_threshold_for_c
         AIS::applyPositionCorrection(position, sensor2vessel_pos, utm_converter);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_RAW);
+    ASSERT_EQ(position.time, corrected_position.time);
 }
 
 TEST_F(AISTest, it_does_no_correction_if_no_yaw_or_cog)
@@ -388,11 +389,12 @@ TEST_F(AISTest, it_corrects_position_using_yaw)
     auto corrected_position =
         AIS::applyPositionCorrection(position, info.reference_position, utm_converter);
 
-    auto vessel2world_gps = utm_converter.convertUTMToGPS(vessel2world);
-    ASSERT_NEAR(vessel2world_gps.latitude, corrected_position.latitude.getDeg(), 1e-3);
-    ASSERT_NEAR(vessel2world_gps.longitude, corrected_position.longitude.getDeg(), 1e-3);
+    auto vessel_pos = utm_converter.convertUTMToGPS(vessel2world);
+    ASSERT_NEAR(vessel_pos.latitude, corrected_position.latitude.getDeg(), 1e-3);
+    ASSERT_NEAR(vessel_pos.longitude, corrected_position.longitude.getDeg(), 1e-3);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_HEADING);
+    ASSERT_EQ(position.time, corrected_position.time);
 }
 
 TEST_F(AISTest, it_corrects_position_using_cog)
@@ -420,9 +422,10 @@ TEST_F(AISTest, it_corrects_position_using_cog)
     auto corrected_position =
         AIS::applyPositionCorrection(position, info.reference_position, utm_converter);
 
-    auto vessel2world_gps = utm_converter.convertUTMToGPS(vessel2world);
-    ASSERT_NEAR(vessel2world_gps.latitude, corrected_position.latitude.getDeg(), 1e-3);
-    ASSERT_NEAR(vessel2world_gps.longitude, corrected_position.longitude.getDeg(), 1e-3);
+    auto vessel_pos = utm_converter.convertUTMToGPS(vessel2world);
+    ASSERT_NEAR(vessel_pos.latitude, corrected_position.latitude.getDeg(), 1e-3);
+    ASSERT_NEAR(vessel_pos.longitude, corrected_position.longitude.getDeg(), 1e-3);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_COURSE);
+    ASSERT_EQ(position.time, corrected_position.time);
 }

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -276,8 +276,8 @@ TEST_F(AISTest, it_selects_yaw_as_vessel_heading_source_if_available)
         position.course_over_ground,
         position.speed_over_ground);
 
-    ASSERT_NEAR(ori.z(), -0.7071068, 1e-3);
-    ASSERT_NEAR(ori.w(), 0.7071068, 1e-3);
+    ASSERT_TRUE(ori.isApprox(
+        Eigen::Quaterniond(Eigen::AngleAxisd(-M_PI / 2, Eigen::Vector3d::UnitZ()))));
     ASSERT_EQ(status,
         ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_HEADING);
 }
@@ -294,8 +294,8 @@ TEST_F(AISTest,
         position.course_over_ground,
         position.speed_over_ground);
 
-    ASSERT_NEAR(ori.z(), -0.7071068, 1e-3);
-    ASSERT_NEAR(ori.w(), 0.7071068, 1e-3);
+    ASSERT_TRUE(ori.isApprox(
+        Eigen::Quaterniond(Eigen::AngleAxisd(-M_PI / 2, Eigen::Vector3d::UnitZ()))));
     ASSERT_EQ(status, ais_base::PositionCorrectionStatus::POSITION_CENTERED_USING_COURSE);
 }
 
@@ -311,8 +311,8 @@ TEST_F(AISTest,
         position.course_over_ground,
         position.speed_over_ground);
 
-    ASSERT_EQ(ori.z(), 0);
-    ASSERT_EQ(ori.w(), 1);
+    ASSERT_TRUE(
+        ori.isApprox(Eigen::Quaterniond(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitZ()))));
     ASSERT_EQ(status, ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
 
@@ -325,8 +325,8 @@ TEST_F(AISTest, it_selects_identity_as_vessel_heading_source_if_no_yaw_or_cog)
         position.course_over_ground,
         position.speed_over_ground);
 
-    ASSERT_EQ(ori.z(), 0);
-    ASSERT_EQ(ori.w(), 1);
+    ASSERT_TRUE(
+        ori.isApprox(Eigen::Quaterniond(Eigen::AngleAxisd(0, Eigen::Vector3d::UnitZ()))));
     ASSERT_EQ(status, ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
 

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -274,12 +274,11 @@ TEST_F(AISTest, it_corrects_position_using_yaw)
     msg.set_hdg(90);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
-        sensor2vessel_in_vessel_pos,
-        utm_converter);
+    ais_base::Position corrected_position =
+        AIS::applyPositionCorrection(position, sensor2vessel_pos, utm_converter);
 
     ASSERT_NEAR(corrected_position.latitude.getDeg(), 44.9991, 1e-4);
     ASSERT_NEAR(corrected_position.longitude.getDeg(), -119.9993, 1e-4);
@@ -296,12 +295,11 @@ TEST_F(AISTest, it_corrects_position_using_cog)
     msg.set_cog(90);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
-        sensor2vessel_in_vessel_pos,
-        utm_converter);
+    ais_base::Position corrected_position =
+        AIS::applyPositionCorrection(position, sensor2vessel_pos, utm_converter);
 
     ASSERT_NEAR(corrected_position.latitude.getDeg(), 44.9991, 1e-4);
     ASSERT_NEAR(corrected_position.longitude.getDeg(), -119.9993, 1e-4);
@@ -317,12 +315,11 @@ TEST_F(AISTest, it_does_no_correction_if_both_yaw_and_cog_are_missing)
     msg.set_sog(0);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
-        sensor2vessel_in_vessel_pos,
-        utm_converter);
+    ais_base::Position corrected_position =
+        AIS::applyPositionCorrection(position, sensor2vessel_pos, utm_converter);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
@@ -336,23 +333,22 @@ TEST_F(AISTest, it_does_no_correction_if_yaw_is_missing_and_sog_is_below_thresho
     msg.set_cog(90);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
-        sensor2vessel_in_vessel_pos,
-        utm_converter);
+    ais_base::Position corrected_position =
+        AIS::applyPositionCorrection(position, sensor2vessel_pos, utm_converter);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
 
 TEST_F(AISTest, it_throws_runtime_error_if_position_has_no_value)
 {
-    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
     try {
-        AIS::applyPositionCorrection({}, sensor2vessel_in_vessel_pos, utm_converter);
+        AIS::applyPositionCorrection({}, sensor2vessel_pos, utm_converter);
     }
     catch (std::invalid_argument const& e) {
         ASSERT_STREQ(e.what(), "Position data is unavailable.");

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -354,7 +354,7 @@ TEST_F(AISTest, it_throws_runtime_error_if_position_has_no_value)
     try {
         AIS::applyPositionCorrection({}, sensor2vessel_in_vessel_pos, utm_converter);
     }
-    catch (const std::runtime_error& e) {
+    catch (std::invalid_argument const& e) {
         ASSERT_STREQ(e.what(), "Position data is unavailable.");
     }
 }

--- a/test/test_AIS.cpp
+++ b/test/test_AIS.cpp
@@ -274,11 +274,12 @@ TEST_F(AISTest, it_corrects_position_using_yaw)
     msg.set_hdg(90);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position =
-        AIS::applyPositionCorrection(position, vessel_reference_position, utm_converter);
+    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
+        sensor2vessel_in_vessel_pos,
+        utm_converter);
 
     ASSERT_NEAR(corrected_position.latitude.getDeg(), 44.9991, 1e-4);
     ASSERT_NEAR(corrected_position.longitude.getDeg(), -119.9993, 1e-4);
@@ -295,11 +296,12 @@ TEST_F(AISTest, it_corrects_position_using_cog)
     msg.set_cog(90);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position =
-        AIS::applyPositionCorrection(position, vessel_reference_position, utm_converter);
+    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
+        sensor2vessel_in_vessel_pos,
+        utm_converter);
 
     ASSERT_NEAR(corrected_position.latitude.getDeg(), 44.9991, 1e-4);
     ASSERT_NEAR(corrected_position.longitude.getDeg(), -119.9993, 1e-4);
@@ -315,11 +317,12 @@ TEST_F(AISTest, it_does_no_correction_if_both_yaw_and_cog_are_missing)
     msg.set_sog(0);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position =
-        AIS::applyPositionCorrection(position, vessel_reference_position, utm_converter);
+    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
+        sensor2vessel_in_vessel_pos,
+        utm_converter);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
@@ -333,22 +336,23 @@ TEST_F(AISTest, it_does_no_correction_if_yaw_is_missing_and_sog_is_below_thresho
     msg.set_cog(90);
     auto position = AIS::getPosition(msg);
 
-    base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
-    ais_base::Position corrected_position =
-        AIS::applyPositionCorrection(position, vessel_reference_position, utm_converter);
+    ais_base::Position corrected_position = AIS::applyPositionCorrection(position,
+        sensor2vessel_in_vessel_pos,
+        utm_converter);
     ASSERT_EQ(corrected_position.correction_status,
         ais_base::PositionCorrectionStatus::POSITION_RAW);
 }
 
 TEST_F(AISTest, it_throws_runtime_error_if_position_has_no_value)
 {
-    base::Vector3d vessel_reference_position(100.0, 50.0, 0.0);
+    base::Vector3d sensor2vessel_in_vessel_pos(100.0, 50.0, 0.0);
     gps_base::UTMConverter utm_converter = createUTMConverter();
 
     try {
-        AIS::applyPositionCorrection({}, vessel_reference_position, utm_converter);
+        AIS::applyPositionCorrection({}, sensor2vessel_in_vessel_pos, utm_converter);
     }
     catch (const std::runtime_error& e) {
         ASSERT_STREQ(e.what(), "Position data is unavailable.");


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-ais_base/pull/6
- [ ] https://github.com/tidewise/drivers-orogen-nmea0183/pull/10

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
[sc-67374]
This PR moves the position correction code here

# How I did it
Moved the code that was previously in `drivers/orogen/nmea0183` and made some improvements in the code.

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
Unit tests

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
